### PR TITLE
Remove the decompiled directory when netbeans is about to be closed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
             <artifactId>org-netbeans-modules-java-source</artifactId>
             <version>RELEASE130</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-modules</artifactId>
+            <version>RELEASE130</version>
+        </dependency>
     </dependencies>
     
     <repositories>

--- a/src/main/java/com/mrf/javadecompiler/openapi/Installer.java
+++ b/src/main/java/com/mrf/javadecompiler/openapi/Installer.java
@@ -21,8 +21,9 @@ import com.mrf.javadecompiler.constants.Constants;
 import com.mrf.javadecompiler.exception.ExceptionHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.openide.modules.ModuleInstall;
 
-public class Installer extends org.openide.modules.ModuleInstall {
+public class Installer extends ModuleInstall {
 
     @Override
     public boolean closing() {

--- a/src/main/java/com/mrf/javadecompiler/openapi/Installer.java
+++ b/src/main/java/com/mrf/javadecompiler/openapi/Installer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 moacirrf
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.mrf.javadecompiler.openapi;
+
+import com.machinezoo.noexception.Exceptions;
+import com.mrf.javadecompiler.constants.Constants;
+import com.mrf.javadecompiler.exception.ExceptionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class Installer extends org.openide.modules.ModuleInstall {
+
+    @Override
+    public boolean closing() {
+        this.clearTempFolder(Path.of(Constants.TEMP_DIR_PLUGIN));
+        return super.closing();
+    }
+    /**
+     * Will remove recursivelly all decompiled classes, when close Netbeans.
+     * 
+     * @param path 
+     */
+    private void clearTempFolder(Path path) {
+        Exceptions.wrap(ex -> ExceptionHandler.handleException(ex)).run(() -> {
+            if (Files.isDirectory(path) && Files.list(path).count() > 0) {
+                Files.list(path).forEach(it -> this.clearTempFolder(it));
+            }
+            Files.deleteIfExists(path);
+        });
+    }
+
+}

--- a/src/main/nbm/manifest.mf
+++ b/src/main/nbm/manifest.mf
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Localizing-Bundle: com/mrf/javadecompiler/Bundle.properties
 OpenIDE-Module-Requires: org.openide.windows.WindowManager
+OpenIDE-Module-Install: com/mrf/javadecompiler/openapi/Installer.class
 


### PR DESCRIPTION
Include an implementation of ModuleInstall, to remove the decompiled directory when netbeans is about to be closed.

![image](https://user-images.githubusercontent.com/950706/171026700-96855a65-3db3-4997-aab5-4901125851df.png)
